### PR TITLE
[WIP] Replace nodejs prom-client with promjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,8 @@
     "@libp2p/interface-metrics": "^4.0.2",
     "@libp2p/logger": "^2.0.2",
     "it-foreach": "^1.0.0",
-    "it-stream-types": "^1.0.4"
+    "it-stream-types": "^1.0.4",
+    "promjs": "^0.4.2"
   },
   "devDependencies": {
     "@libp2p/interface-mocks": "^8.0.4",

--- a/src/counter-group.ts
+++ b/src/counter-group.ts
@@ -1,43 +1,42 @@
 import type { CounterGroup, CalculateMetric } from '@libp2p/interface-metrics'
-import { Counter as PromCounter, CollectFunction } from 'prom-client'
+import type { CounterType } from 'promjs'
 import { normaliseString, CalculatedMetric } from './utils.js'
 import type { PrometheusCalculatedMetricOptions } from './index.js'
 
 export class PrometheusCounterGroup implements CounterGroup, CalculatedMetric<Record<string, number>> {
-  private readonly counter: PromCounter
+  private readonly counter: CounterType
   private readonly label: string
   private readonly calculators: Array<CalculateMetric<Record<string, number>>>
 
   constructor (name: string, opts: PrometheusCalculatedMetricOptions<Record<string, number>>) {
     name = normaliseString(name)
     const help = normaliseString(opts.help ?? name)
-    const label = this.label = normaliseString(opts.label ?? name)
-    let collect: CollectFunction<PromCounter<any>> | undefined
+    this.label = normaliseString(opts.label ?? name)
+    // let collect: any | undefined
     this.calculators = []
 
     // calculated metric
-    if (opts?.calculate != null) {
-      this.calculators.push(opts.calculate)
-      const self = this
+    // TODO: Implement and use collect
+    // if (opts?.calculate != null) {
+    //   this.calculators.push(opts.calculate)
+    //   const self = this
 
-      collect = async function () {
-        await Promise.all(self.calculators.map(async calculate => {
-          const values = await calculate()
+    //   collect = async function () {
+    //     await Promise.all(self.calculators.map(async calculate => {
+    //       const values = await calculate()
 
-          Object.entries(values).forEach(([key, value]) => {
-            this.inc({ [label]: key }, value)
-          })
-        }))
-      }
-    }
+    //       Object.entries(values).forEach(([key, value]) => {
+    //         this.inc({ [label]: key }, value)
+    //       })
+    //     }))
+    //   }
+    // }
 
-    this.counter = new PromCounter({
+    this.counter = opts.registry.create(
+      'counter',
       name,
-      help,
-      labelNames: [this.label],
-      registers: opts.registry !== undefined ? [opts.registry] : undefined,
-      collect
-    })
+      help
+    )
   }
 
   addCalculator (calculator: CalculateMetric<Record<string, number>>) {
@@ -48,7 +47,7 @@ export class PrometheusCounterGroup implements CounterGroup, CalculatedMetric<Re
     Object.entries(values).forEach(([key, value]) => {
       const inc = typeof value === 'number' ? value : 1
 
-      this.counter.inc({ [this.label]: key }, inc)
+      this.counter.add(inc, { [this.label]: key })
     })
   }
 

--- a/src/counter.ts
+++ b/src/counter.ts
@@ -12,28 +12,25 @@ export class PrometheusCounter implements Counter, CalculatedMetric {
     const help = normaliseString(opts.help ?? name)
     // TODO: Use labels in counter (not used in old code)
     // const labels = opts.label != null ? [normaliseString(opts.label)] : []
-    // let collect: any | undefined
     this.calculators = []
 
     // calculated metric
-    // TODO: Implement and use collect
-    // if (opts?.calculate != null) {
-    //   this.calculators.push(opts.calculate)
-    //   const self = this
-
-    //   collect = async function () {
-    //     const values = await Promise.all(self.calculators.map(async calculate => await calculate()))
-    //     const sum = values.reduce((acc, curr) => acc + curr, 0)
-
-    //     this.inc(sum)
-    //   }
-    // }
+    if (opts?.calculate != null) {
+      this.calculators.push(opts.calculate)
+    }
 
     this.counter = opts.registry.create(
       'counter',
       name,
       help
     )
+  }
+
+  async calculate () {
+    const values = await Promise.all(this.calculators.map(async calculate => await calculate()))
+    const sum = values.reduce((acc, curr) => acc + curr, 0)
+
+    this.counter.add(sum)
   }
 
   addCalculator (calculator: CalculateMetric) {

--- a/src/counter.ts
+++ b/src/counter.ts
@@ -1,39 +1,39 @@
 import type { CalculateMetric, Counter } from '@libp2p/interface-metrics'
-import { CollectFunction, Counter as PromCounter } from 'prom-client'
+import type { CounterType } from 'promjs'
 import type { PrometheusCalculatedMetricOptions } from './index.js'
 import { normaliseString, CalculatedMetric } from './utils.js'
 
 export class PrometheusCounter implements Counter, CalculatedMetric {
-  private readonly counter: PromCounter
+  private readonly counter: CounterType
   private readonly calculators: CalculateMetric[]
 
   constructor (name: string, opts: PrometheusCalculatedMetricOptions) {
     name = normaliseString(name)
     const help = normaliseString(opts.help ?? name)
-    const labels = opts.label != null ? [normaliseString(opts.label)] : []
-    let collect: CollectFunction<PromCounter<any>> | undefined
+    // TODO: Use labels in counter (not used in old code)
+    // const labels = opts.label != null ? [normaliseString(opts.label)] : []
+    // let collect: any | undefined
     this.calculators = []
 
     // calculated metric
-    if (opts?.calculate != null) {
-      this.calculators.push(opts.calculate)
-      const self = this
+    // TODO: Implement and use collect
+    // if (opts?.calculate != null) {
+    //   this.calculators.push(opts.calculate)
+    //   const self = this
 
-      collect = async function () {
-        const values = await Promise.all(self.calculators.map(async calculate => await calculate()))
-        const sum = values.reduce((acc, curr) => acc + curr, 0)
+    //   collect = async function () {
+    //     const values = await Promise.all(self.calculators.map(async calculate => await calculate()))
+    //     const sum = values.reduce((acc, curr) => acc + curr, 0)
 
-        this.inc(sum)
-      }
-    }
+    //     this.inc(sum)
+    //   }
+    // }
 
-    this.counter = new PromCounter({
+    this.counter = opts.registry.create(
+      'counter',
       name,
-      help,
-      labelNames: labels,
-      registers: opts.registry !== undefined ? [opts.registry] : undefined,
-      collect
-    })
+      help
+    )
   }
 
   addCalculator (calculator: CalculateMetric) {
@@ -41,7 +41,7 @@ export class PrometheusCounter implements Counter, CalculatedMetric {
   }
 
   increment (value: number = 1): void {
-    this.counter.inc(value)
+    this.counter.add(value)
   }
 
   reset (): void {

--- a/src/metric-group.ts
+++ b/src/metric-group.ts
@@ -1,43 +1,42 @@
 import type { CalculateMetric, MetricGroup, StopTimer } from '@libp2p/interface-metrics'
-import { CollectFunction, Gauge } from 'prom-client'
+import type { GaugeType } from 'promjs'
 import type { PrometheusCalculatedMetricOptions } from './index.js'
 import { normaliseString, CalculatedMetric } from './utils.js'
 
 export class PrometheusMetricGroup implements MetricGroup, CalculatedMetric<Record<string, number>> {
-  private readonly gauge: Gauge
+  private readonly gauge: GaugeType
   private readonly label: string
   private readonly calculators: Array<CalculateMetric<Record<string, number>>>
 
   constructor (name: string, opts: PrometheusCalculatedMetricOptions<Record<string, number>>) {
     name = normaliseString(name)
     const help = normaliseString(opts.help ?? name)
-    const label = this.label = normaliseString(opts.label ?? name)
-    let collect: CollectFunction<Gauge<any>> | undefined
+    this.label = normaliseString(opts.label ?? name)
+    // let collect: any | undefined
     this.calculators = []
 
     // calculated metric
-    if (opts?.calculate != null) {
-      this.calculators.push(opts.calculate)
-      const self = this
+    // TODO: Implement and use collect
+    // if (opts?.calculate != null) {
+    //   this.calculators.push(opts.calculate)
+    //   const self = this
 
-      collect = async function () {
-        await Promise.all(self.calculators.map(async calculate => {
-          const values = await calculate()
+    //   collect = async function () {
+    //     await Promise.all(self.calculators.map(async calculate => {
+    //       const values = await calculate()
 
-          Object.entries(values).forEach(([key, value]) => {
-            this.set({ [label]: key }, value)
-          })
-        }))
-      }
-    }
+    //       Object.entries(values).forEach(([key, value]) => {
+    //         this.set({ [label]: key }, value)
+    //       })
+    //     }))
+    //   }
+    // }
 
-    this.gauge = new Gauge({
+    this.gauge = opts.registry.create(
+      'gauge',
       name,
-      help,
-      labelNames: [this.label],
-      registers: opts.registry !== undefined ? [opts.registry] : undefined,
-      collect
-    })
+      help
+    )
   }
 
   addCalculator (calculator: CalculateMetric<Record<string, number>>) {
@@ -46,7 +45,7 @@ export class PrometheusMetricGroup implements MetricGroup, CalculatedMetric<Reco
 
   update (values: Record<string, number>): void {
     Object.entries(values).forEach(([key, value]) => {
-      this.gauge.set({ [this.label]: key }, value)
+      this.gauge.set(value, { [this.label]: key })
     })
   }
 
@@ -54,7 +53,7 @@ export class PrometheusMetricGroup implements MetricGroup, CalculatedMetric<Reco
     Object.entries(values).forEach(([key, value]) => {
       const inc = typeof value === 'number' ? value : 1
 
-      this.gauge.inc({ [this.label]: key }, inc)
+      this.gauge.add(inc, { [this.label]: key })
     })
   }
 
@@ -62,7 +61,7 @@ export class PrometheusMetricGroup implements MetricGroup, CalculatedMetric<Reco
     Object.entries(values).forEach(([key, value]) => {
       const dec = typeof value === 'number' ? value : 1
 
-      this.gauge.dec({ [this.label]: key }, dec)
+      this.gauge.sub(dec, { [this.label]: key })
     })
   }
 
@@ -71,8 +70,14 @@ export class PrometheusMetricGroup implements MetricGroup, CalculatedMetric<Reco
   }
 
   timer (key: string): StopTimer {
-    return this.gauge.startTimer({
-      key: 0
-    })
+    const startDate = new Date()
+
+    return () => {
+      const timeElapsedInMs = (new Date()).getTime() - startDate.getTime()
+
+      this.gauge.set(timeElapsedInMs / 1000, {
+        key: 0
+      })
+    }
   }
 }

--- a/src/metric-group.ts
+++ b/src/metric-group.ts
@@ -12,31 +12,28 @@ export class PrometheusMetricGroup implements MetricGroup, CalculatedMetric<Reco
     name = normaliseString(name)
     const help = normaliseString(opts.help ?? name)
     this.label = normaliseString(opts.label ?? name)
-    // let collect: any | undefined
     this.calculators = []
 
     // calculated metric
-    // TODO: Implement and use collect
-    // if (opts?.calculate != null) {
-    //   this.calculators.push(opts.calculate)
-    //   const self = this
-
-    //   collect = async function () {
-    //     await Promise.all(self.calculators.map(async calculate => {
-    //       const values = await calculate()
-
-    //       Object.entries(values).forEach(([key, value]) => {
-    //         this.set({ [label]: key }, value)
-    //       })
-    //     }))
-    //   }
-    // }
+    if (opts?.calculate != null) {
+      this.calculators.push(opts.calculate)
+    }
 
     this.gauge = opts.registry.create(
       'gauge',
       name,
       help
     )
+  }
+
+  async calculate () {
+    await Promise.all(this.calculators.map(async calculate => {
+      const values = await calculate()
+
+      Object.entries(values).forEach(([key, value]) => {
+        this.gauge.set(value, { [this.label]: key })
+      })
+    }))
   }
 
   addCalculator (calculator: CalculateMetric<Record<string, number>>) {

--- a/src/metric.ts
+++ b/src/metric.ts
@@ -12,28 +12,25 @@ export class PrometheusMetric implements Metric {
     const help = normaliseString(opts.help ?? name)
     // TODO: Use labels in counter (not used in old code)
     // const labels = opts.label != null ? [normaliseString(opts.label)] : []
-    // let collect: any | undefined
     this.calculators = []
 
     // calculated metric
-    // TODO: Implement and use collect
-    // if (opts?.calculate != null) {
-    //   this.calculators.push(opts.calculate)
-    //   const self = this
-
-    //   collect = async function () {
-    //     const values = await Promise.all(self.calculators.map(async calculate => await calculate()))
-    //     const sum = values.reduce((acc, curr) => acc + curr, 0)
-
-    //     this.set(sum)
-    //   }
-    // }
+    if (opts?.calculate != null) {
+      this.calculators.push(opts.calculate)
+    }
 
     this.gauge = opts.registry.create(
       'gauge',
       name,
       help
     )
+  }
+
+  async calculate () {
+    const values = await Promise.all(this.calculators.map(async calculate => await calculate()))
+    const sum = values.reduce((acc, curr) => acc + curr, 0)
+
+    this.gauge.set(sum)
   }
 
   addCalculator (calculator: CalculateMetric) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,6 @@
   },
   "include": [
     "src",
-    "test"
+    // "test"
   ]
 }


### PR DESCRIPTION
- Use promjs instead of prom-client to enable libp2p metrics in browser
- Add `getMetrics` method to run async calculations and get updated metrics (similar to `prom-client` collect option)